### PR TITLE
Add FoR-SALE news and publication

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -5,6 +5,11 @@
 #   headline: "[Announcement Verb] that [Name/Team]'s paper, '[Full Paper Title]', has been accepted for [Conference Name]! Many congratulations to [Name]!"
 #   top: 1
 
+- date: <i>July 9th 2026</i>
+  headline: "We are excited to announce that Tanawan's paper, 'FoR-SALE: Frame of Reference-guided Spatial Adjustment in LLM-based Diffusion Editing', has been accepted for COLM! Many congratulations to Tanawan!"
+  link: https://arxiv.org/abs/2509.23452
+  top: 1
+
 - date: <i>June 16th 2026</i>
   headline: "We are excited to announce that Darius's paper, 'Extracting Probabilistic Knowledge from Large Language Models for Bayesian Network Parameterization', has been accepted for Transactions on Machine Learning Research (TMLR)! Many congratulations to Darius!"
   top: 1

--- a/_data/publist.yml
+++ b/_data/publist.yml
@@ -11,6 +11,14 @@
 #     - url:
 #       display: Code
 
+- title: "FoR-SALE: Frame of Reference-guided Spatial Adjustment in LLM-based Diffusion Editing"
+  authors: Tanawan Premsri, Parisa Kordjamshidi
+  venue: The Conference on Language Modeling (COLM)
+  year: 2026
+  links:
+    - url: https://arxiv.org/abs/2509.23452
+      display: PDF
+
 - title: "Extracting Probabilistic Knowledge from Large Language Models for Bayesian Network Parameterization"
   authors: Aliakbar Nafar, K. Brent Venable, Zijun Cui, Parisa Kordjamshidi
   venue: Transactions on Machine Learning Research (TMLR)


### PR DESCRIPTION
## Summary
- Add July 9, 2026 news item for Tanawan's FoR-SALE paper accepted at COLM
- Add FoR-SALE to the 2026 publication list with the arXiv link

## Verification
- ruby -e "require 'yaml'; YAML.load_file('_data/news.yml'); YAML.load_file('_data/publist.yml')"
- eval "$(rbenv init - zsh)"; bundle exec jekyll build